### PR TITLE
It builds on Visual Studio 2022 now!

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -28,11 +28,11 @@ jobs:
       - name: Restore it!
         shell: cmd
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && msbuild -t:restore -m -p:RestorePackagesConfig=true -p:Configuration=Release src\AppInstallerCLI.sln
+          "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && msbuild -t:restore -m -p:RestorePackagesConfig=true -p:Configuration=Release src\AppInstallerCLI.sln
       - name: Build it!
         shell: cmd
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && msbuild -m -p:Configuration=Release src\AppInstallerCLI.sln
+          "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && msbuild -m -p:Configuration=Release -p:Platform=x64 src\AppInstallerCLI.sln
       - name: Make that archive!
         run: |
           cp src\x64\Release\WindowsPackageManager\WindowsPackageManager.dll src\x64\Release\AppInstallerCLI\WindowsPackageManager.dll


### PR DESCRIPTION
Since winget uses the Windows 11 SDK now (which is installed on the windows-latest image, unlike the 10 SDK), we can compile it on Visual Studio 2022 now. Not that it makes much difference, but hey, latest is latest.